### PR TITLE
Only show council org links when they exist

### DIFF
--- a/src/pages/MembersPage/index.js
+++ b/src/pages/MembersPage/index.js
@@ -67,12 +67,18 @@ function MembersPage() {
                             </div>
                         </ModalBody>
                         <ModalFooter>
-                            <a className="btn nav__toggle" href={currOrg.website} target="_blank">
-                                <i className="fa fa-link"></i>  Website
-                            </a>
-                            <a className="btn nav__toggle" href={`mailto:${currOrg.email}`}>
-                                <i className="fa fa-envelope"></i>  Email
-                            </a>
+                            { 
+                                currOrg.website &&
+                                <a className="btn nav__toggle" href={currOrg.website} target="_blank">
+                                    <i className="fa fa-link"></i>  Website
+                                </a> 
+                            }
+                            { 
+                                currOrg.email &&
+                                <a className="btn nav__toggle" href={`mailto:${currOrg.email}`}>
+                                    <i className="fa fa-envelope"></i>  Email
+                                </a>
+                            }
                         </ModalFooter>
                     </>}
             </Modal>


### PR DESCRIPTION
Some council orgs aren't providing both their website and their email, so now the links will only show if there's a value. 

If there aren't any values, it'll be an empty footer so that the styling is consistent with other orgs who supply at least one piece of info