### PR TITLE
Added "set NODE_OPTIONS=--openssl-legacy-provider" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,11 @@
   "homepage": "http://tesc.ucsd.edu/",
   "scripts": {
     "analyze": "source-map-explorer build/static/js/main.*",
-    "start": "react-scripts start",
+    "start": "set NODE_OPTIONS=--openssl-legacy-provider && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
+    
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Temporary fix to allow for tesc.ucsd.edu website to compile and deploy; future goal will be to not rely on openssl-legacy-provider