### PR TITLE
Update EOTG and DECaF page links

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,5 @@
 name: Deploy
 
-# Deploy on every push to the repository on master
-# Or whenever we manually run it
 on:
   push:
     branches:
@@ -13,7 +11,7 @@ jobs:
     name: Builds tesc.ucsd.edu for deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: '11.x'
@@ -25,12 +23,8 @@ jobs:
       - name: Build tesc.ucsd.edu
         run: npm install && CI=false npm run build
         shell: bash
-      - name: Move files with rsync
-        env:
-          SSH_PASSWORD: ${{ secrets.SSH_PASSWORD }}
-        run: |
-          sudo apt-get install expect
-          sudo chmod +x ./scripts/lookup-test-website
-          sudo chmod +x ./scripts/rsync-website.except
-          ./scripts/lookup-test-website
-          ./scripts/rsync-website.except $SSH_PASSWORD
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-artifacts
+          path: build # or specify the directory where your build files are located

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm install && CI=false npm run build
         shell: bash
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: . # or specify the directory where your build files are located

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,4 +27,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: build-artifacts
-          path: build # or specify the directory where your build files are located
+          path: . # or specify the directory where your build files are located

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -87,7 +87,7 @@ function Routes() {
                     component={withLayout(FinancePage, true)}
                 />
 
-                // <Route path="/decaf" component={DecafRoutes} />
+                {/* <Route path="/decaf" component={DecafRoutes} /> */}
                 <Route
                     exact
                     path="/decaf"

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -96,6 +96,25 @@ function Routes() {
                         return null;
                     }}
                 />
+
+                <Route
+                    exact
+                    path="/upcomingevents/decaf"
+                    component={() => {
+                        window.location.href = "https://decafucsd.com";
+                        return null;
+                    }}
+                />
+
+                <Route
+                    exact
+                    path="/upcomingEvents/decaf"
+                    component={() => {
+                        window.location.href = "https://decafucsd.com";
+                        return null;
+                    }}
+                />
+                        
                 <Route path="/matcha" component={MatchaRoutes} />
                 <Route path="/enspire" component={EnspireRoutes} />
 
@@ -108,10 +127,28 @@ function Routes() {
                         return null;
                     }}
                 />
+
+                <Route
+                    exact
+                    path="/upcomingevents/eotg"
+                    component={() => {
+                        window.location.href = "https://eotgucsd.com";
+                        return null;
+                    }}
+                />
+
+                <Route
+                    exact
+                    path="/upcomingEvents/eotg"
+                    component={() => {
+                        window.location.href = "https://eotgucsd.com";
+                        return null;
+                    }}
+                />
                         
                 
-                <Route path="/upcomingevents/eotg" component={UpcomingEOTGRoutes} />
-                <Route path="/upcomingevents/decaf" component={UpcomingDecafRoutes} />
+                {/* <Route path="/upcomingevents/eotg" component={UpcomingEOTGRoutes} /> */}
+                {/* <Route path="/upcomingevents/decaf" component={UpcomingDecafRoutes} /> */}
 
                 <Route component={withLayout(NotFoundPage)} />
             </Switch>

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -7,7 +7,7 @@ import Layout from './layouts/Layout';
 //import DecafRoutes from './pages/DecafPage/Routes';
 import MatchaRoutes from './pages/MatchaPage/Routes';
 import EnspireRoutes from './pages/EnspirePage/Routes';
-import EOTGRoutes from './pages/EOTGPage/Routes';
+//import EOTGRoutes from './pages/EOTGPage/Routes';
 import UpcomingEOTGRoutes from './pages/UpcomingEvents/EOTGPage/Routes'
 import UpcomingDecafRoutes from './pages/UpcomingEvents/DecafPage/Routes';
 import HomePage from './pages/HomePage';
@@ -98,7 +98,18 @@ function Routes() {
                 />
                 <Route path="/matcha" component={MatchaRoutes} />
                 <Route path="/enspire" component={EnspireRoutes} />
-                <Route path="/eotg" component={EOTGRoutes} />
+
+                {/* <Route path="/eotg" component={EOTGRoutes} /> */}
+                <Route
+                    exact
+                    path="/eotg"
+                    component={() => {
+                        window.location.href = "https://eotgucsd.com";
+                        return null;
+                    }}
+                />
+                        
+                
                 <Route path="/upcomingevents/eotg" component={UpcomingEOTGRoutes} />
                 <Route path="/upcomingevents/decaf" component={UpcomingDecafRoutes} />
 

--- a/src/Routes.js
+++ b/src/Routes.js
@@ -4,7 +4,7 @@ import { Spinner } from 'reactstrap';
 
 import Layout from './layouts/Layout';
 
-import DecafRoutes from './pages/DecafPage/Routes';
+//import DecafRoutes from './pages/DecafPage/Routes';
 import MatchaRoutes from './pages/MatchaPage/Routes';
 import EnspireRoutes from './pages/EnspirePage/Routes';
 import EOTGRoutes from './pages/EOTGPage/Routes';
@@ -87,7 +87,15 @@ function Routes() {
                     component={withLayout(FinancePage, true)}
                 />
 
-                <Route path="/decaf" component={DecafRoutes} />
+                // <Route path="/decaf" component={DecafRoutes} />
+                <Route
+                    exact
+                    path="/decaf"
+                    component={() => {
+                        window.location.href = "https://decafucsd.com";
+                        return null;
+                    }}
+                />
                 <Route path="/matcha" component={MatchaRoutes} />
                 <Route path="/enspire" component={EnspireRoutes} />
                 <Route path="/eotg" component={EOTGRoutes} />


### PR DESCRIPTION
Redirects TESC domains:

tesc.ucsd.edu/eotg -> https://eotgucsd.com 

and 

tesc.ucsd.edu/decaf -> https://decafucsd.com

in src/Routes.js, and updates deploy.yml according to action version compatibility.


Here's the test link for website redirection: https://tesc-ucsd-edu.vercel.app/